### PR TITLE
Update sort in Received Materials Tab

### DIFF
--- a/app/views/material_receptions/_material_receptions.html.erb
+++ b/app/views/material_receptions/_material_receptions.html.erb
@@ -1,6 +1,8 @@
 <table class="table table-striped table-hover"
   data-psd-component-class="DataTableInitialization"
-  data-psd-component-parameters="<%= { :order => [[1, 'desc']]}.to_json %>">
+  data-psd-component-parameters="<%= { :order => [[1, 'desc']], :columns => [
+    { :name => 'Barcode', :orderable => false },  { :name => 'Received at', :orderable => true }
+  ] }.to_json %>">
   <thead>
     <th>Barcode</th>
     <th>Received at</th>


### PR DESCRIPTION
sort by barcode was broken as it sorts as if they were strings, so removed that, and kept Received at sort by default and orderable on column